### PR TITLE
Fix export statement for Plugin class

### DIFF
--- a/examples/app-plugins/clock/clock-plugin.js
+++ b/examples/app-plugins/clock/clock-plugin.js
@@ -7,7 +7,7 @@
 * 
 */
 
-export class Plugin extends AppPlugin {
+class Plugin extends AppPlugin {
 	
 	onLoad() {
 		this.addLiveTimeToStatusBar();


### PR DESCRIPTION
Removes "export" from plugin class to go with updated plugin integration